### PR TITLE
fix: replace Document PIP API with window.open() popup

### DIFF
--- a/src/primary/infrastructure/composables/pictureInPicture.ts
+++ b/src/primary/infrastructure/composables/pictureInPicture.ts
@@ -1,28 +1,42 @@
 import { Component, computed, createApp } from 'vue';
 import { provide } from '@/primary/infrastructure/dependency-injection';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const win = window as any;
+let pipWindow: Window | null = null;
 
 export const usePictureInPicture = () => {
-    const isSupported = computed(() => !!win.documentPictureInPicture);
-    const isActive = () =>
-        isSupported.value && !!win.documentPictureInPicture.window;
+    const isSupported = computed(() => true);
+    const isActive = () => !!pipWindow && !pipWindow.closed;
 
-    const startPictureInPicture = async (
+    const startPictureInPicture = (
         component: Component,
         props: Record<string, unknown> = {}
     ) => {
         if (isActive()) return console.log('PIP is already active');
-        if (!isSupported.value) return console.log('PIP is not supported');
+
+        const popup = window.open(
+            '',
+            '_blank',
+            'popup=yes,width=240,height=220'
+        );
+
+        if (!popup) return console.log('Popup was blocked');
+
+        pipWindow = popup;
+        popup.addEventListener('beforeunload', () => {
+            pipWindow = null;
+        });
+
+        appendStyles(popup);
+        popup.document.body.style.margin = '0';
 
         const rootEl = mountComponent(component, props);
-        return startPipWindow(rootEl);
+        popup.document.body.appendChild(rootEl);
     };
 
     const closePictureInPicture = () => {
         if (!isActive()) return;
-        win.documentPictureInPicture.window.close();
+        pipWindow?.close();
+        pipWindow = null;
     };
 
     return {
@@ -33,14 +47,19 @@ export const usePictureInPicture = () => {
     };
 };
 
-async function startPipWindow(rootEl: HTMLElement) {
-    const pipWindow = await win.documentPictureInPicture.requestWindow({
-        width: 240,
-        height: 220
+function appendStyles(target: Window) {
+    [...document.styleSheets].forEach((styleSheet) => {
+        try {
+            const cssRules = [...styleSheet.cssRules]
+                .map((rule) => rule.cssText)
+                .join('');
+            const style = document.createElement('style');
+            style.textContent = cssRules;
+            target.document.head.appendChild(style);
+        } catch {
+            // cross-origin stylesheets are not accessible
+        }
     });
-
-    appendStyles(pipWindow);
-    pipWindow.document.body.appendChild(rootEl);
 }
 
 function mountComponent(
@@ -50,19 +69,5 @@ function mountComponent(
     const app = createApp(component, props);
     provide(app);
     const vm = app.mount(document.createElement('div'));
-    const rootEl = vm.$el as HTMLElement;
-    return rootEl;
-}
-
-function appendStyles(pipWindow: Window) {
-    [...document.styleSheets].forEach((styleSheet) => {
-        const cssRules = [...styleSheet.cssRules]
-            .map((rule) => rule.cssText)
-            .join('');
-
-        const style = document.createElement('style');
-
-        style.textContent = cssRules;
-        pipWindow.document.head.appendChild(style);
-    });
+    return vm.$el as HTMLElement;
 }

--- a/src/primary/infrastructure/composables/pomoRunner.ts
+++ b/src/primary/infrastructure/composables/pomoRunner.ts
@@ -130,7 +130,10 @@ export const usePomoRunner = () => {
 
         if (_tickStartTime !== null && _timeLeftAtTickStart !== null) {
             const elapsed = Math.floor((Date.now() - _tickStartTime) / 1000);
-            pomoStore.session.timeLeft = Math.max(_timeLeftAtTickStart - elapsed, 0);
+            pomoStore.session.timeLeft = Math.max(
+                _timeLeftAtTickStart - elapsed,
+                0
+            );
         } else {
             pomoStore.session.timeLeft = Math.max(
                 pomoStore.session.timeLeft - 1,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,5 +10,5 @@ export default defineConfig({
         alias: {
             '@': fileURLToPath(new URL('./src', import.meta.url))
         }
-    },
+    }
 });


### PR DESCRIPTION
## Summary

- Replaces `documentPictureInPicture.requestWindow()` with `window.open()` to create the miniature floating window
- The popup window persists independently of tab focus/navigation, fixing the Arc browser issue where the Document PIP window closed on tab switch
- `isSupported` now always returns `true` (popup is universally available), so the PIP button always shows
- Tracks popup state via a module-level `pipWindow` ref; `beforeunload` listener keeps it in sync when the user closes the popup manually
- Added per-stylesheet try/catch in `appendStyles` to safely handle cross-origin stylesheets

Closes VIN-11

## Test plan

- [ ] Open app, start a session, click the PIP button — a floating popup window should appear
- [ ] Switch tabs or click elsewhere — popup should remain open
- [ ] Close the popup manually — clicking PIP again should re-open it
- [ ] Click the PIP button again from the app — popup should close
- [ ] Test in Arc, Chrome, and Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)